### PR TITLE
♻️ Replace mock with spyOn

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,133 +2,21 @@
 
 Repo for researching mocking functionality in jest.
 
+<p align="center">
+<table>
+<tbody>
+<td align="center">
+<img width="2000" height="0"><br>
+<b>Checkout the README on the <a href="https://github.com/karlosos/jest-mock-internal-function">main branch</a> of the repo.</b>
+<img width="2000" height="0">
+</td>
+</tbody>
+</table>
+</p>
+
 ## Problem
 
 Mocking the function that is used by the tested component. In this case is function from `src/demo/utils.js` named `getData` which is used by `WelcomeMessage` component which is rendered inside `App`. While testing `App` we want to be able to mock that `getData` function.
-
-## Solution
-
-### Using `jest.spyOn` fails in 2022
-
-I was trying to recreate [sherwin waters solution](https://stackoverflow.com/a/66669162/3978701) using `jest.spyOn` but it was not working. i still don't know why `jest.spyOn` doesn't work correctly in that case.
-
-**Not working example:**
-
-```js
-// ./demo/welcomeMessage.js
-import { getData } from "./utils"
-
-export const WelcomeMessage = ({name}) => {
-    return getData(name)
-}
-
-// ./demo/utils.js
-const getData = (name) => `Hello ${name}!`;
-
-export { getData }
-
-// ./App.js
-import { WelcomeMessage } from "./demo/welcomeMessage";
-
-function App() {
-  return (
-    <div className="App">
-      <h1>My app</h1>
-      <p>
-        <WelcomeMessage name={'John'} />
-      </p>
-    </div>
-  );
-}
-
-export default App;
-
-// ./App.test.js
-import { render, screen } from '@testing-library/react';
-import App from './App';
-import * as utils from "./demo/utils";
-
-jest.spyOn(utils, "getData").mockReturnValue("mocked message");  // this doesn't work as intended
-
-describe('App', () => {
-  test('renders header', () => {
-    render(<App />);
-    expect(screen.getByText(/My app/i)).toBeInTheDocument()
-  });
-
-  test('renders correct welcome message', () => {
-    render(<App />)
-    expect(screen.getByText(/mocked message/i)).toBeInTheDocument()
-  });
-})
-```
-
-### Solution: using `jest.mock`
-
-Instead of using `import * as ...` we can mock our module with `jest.mock`. Following test works fine:
-
-```jsx
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-jest.mock('./demo/utils', () => ({
-    getData: () => 'mocked message'
-}));
-
-describe('App', () => {
-  test('renders header', () => {
-    render(<App />);
-    expect(screen.getByText(/My app/i)).toBeInTheDocument()
-  });
-
-  test('renders correct welcome message', () => {
-    render(<App />)
-    expect(screen.getByText(/mocked message/i)).toBeInTheDocument()
-  });
-})
-```
-
-### Multiple mock implementations - hacky way
-
-To mock the function with multiple implementations you can use `jest.doMock`. However, the it is required to import modules after mocking. More about `doMock` in [jest documentation](https://jestjs.io/docs/jest-object#jestdomockmodulename-factory-options). Solution based on [this repo by marr](https://github.com/marr/react-test-mock).
-
-```js
-import { render, screen } from '@testing-library/react';
-
-describe('App', () => {
-  beforeEach(() => {
-    jest.resetModules();
-  })
-
-  describe('mocked', () => {
-    beforeEach(() => {
-      jest.doMock('./demo/utils', () => ({
-        getData: () => 'mocked message'
-      }));
-    })
-    test('renders mocked welcome message', async () => {
-      const App = (await import('./App')).default;
-
-      render(<App />)
-      expect(screen.getByText(/mocked message/i)).toBeInTheDocument()
-    });
-  })
-
-  describe('another mocked', () => {
-    beforeEach(() => {
-      jest.doMock('./demo/utils', () => ({
-        getData: () => 'another data'
-      }));
-    })
-    test('renders another mocked welcome message', async () => {
-      const App = (await import('./App')).default;
-
-      render(<App />)
-      expect(screen.getByText(/another data/i)).toBeInTheDocument()
-    });
-  })
-})
-```
 
 ## Scripts
 

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,11 +1,13 @@
 import { render, screen } from '@testing-library/react';
-import App from './App';
 
-jest.mock('./demo/utils', () => ({
-    getData: () => 'mocked message'
-}));
+import App from './App';
+import * as utils from "./demo/utils";
 
 describe('App', () => {
+  beforeEach(() => {
+    jest.spyOn(utils, "getData").mockReturnValue("mocked message");
+  })
+
   test('renders header', () => {
     render(<App />);
     expect(screen.getByText(/My app/i)).toBeInTheDocument()

--- a/src/demo/welcomeMessage.js
+++ b/src/demo/welcomeMessage.js
@@ -1,6 +1,5 @@
 import { getData } from "./utils"
 
 export const WelcomeMessage = ({name}) => {
-    console.log('>> getData', getData)
     return getData(name)
 }


### PR DESCRIPTION
This approach changes `mock` to `spyOn`.

However, I have some problems with it. 

If I change `beforeEach` to `beforeAll` then tests fail:

```
  beforeEach(() => {
    jest.spyOn(utils, "getData").mockReturnValue("mocked message");
  })
```

Moving `jest.spyOn` into top-level of the file also causes error. What's the reason behind that?